### PR TITLE
docs: fix docs of api management

### DIFF
--- a/http-adapters/src/managementApiAdapter/index.ts
+++ b/http-adapters/src/managementApiAdapter/index.ts
@@ -16,7 +16,8 @@ export default function managementApiAdapter(options: {
         bodyParserOptions: {
             limit: "100mb",
             strict: false
-        }
+        },
+        basePath: "/api"
     };
     const isCurrentFileTs = extname(__filename) === ".ts";
     const router = convexpress(convexpressOptions)


### PR DESCRIPTION
Api management are under `/api` prefix. Adding `/api` as base path in convexpress should fix the swagger