### PR TITLE
Integration with external caches (like CDNs)

### DIFF
--- a/core/src/common/Usecase.ts
+++ b/core/src/common/Usecase.ts
@@ -1,5 +1,6 @@
 import IArchiver from "../dependencies/IArchiver";
 import IAuthenticationStrategy from "../dependencies/IAuthenticationStrategy";
+import IExternalCacheService from "../dependencies/IExternalCacheService";
 import IRequestContext from "../dependencies/IRequestContext";
 import IStorages from "../dependencies/IStorages";
 import IUsecaseConfig from "../dependencies/IUsecaseConfig";
@@ -13,21 +14,24 @@ export default abstract class Usecase {
     protected operationLogger: OperationLogger;
     // Dependencies
     protected archiver: IArchiver;
-    protected storages: IStorages;
+    private authenticationStrategies: IAuthenticationStrategy[];
+    private externalCacheServices: IExternalCacheService[];
     private config: IUsecaseConfig;
     private requestContext: IRequestContext;
-    private authenticationStrategies: IAuthenticationStrategy[];
+    protected storages: IStorages;
 
     constructor(options: {
         archiver: IArchiver;
         authenticationStrategies: IAuthenticationStrategy[];
+        externalCacheServices: IExternalCacheService[];
         config: IUsecaseConfig;
         requestContext: IRequestContext;
         storages: IStorages;
     }) {
         // Dependencies
-        this.authenticationStrategies = options.authenticationStrategies;
         this.archiver = options.archiver;
+        this.authenticationStrategies = options.authenticationStrategies;
+        this.externalCacheServices = options.externalCacheServices;
         this.config = options.config;
         this.requestContext = options.requestContext;
         this.storages = options.storages;
@@ -54,6 +58,7 @@ export default abstract class Usecase {
         new (dependencies: {
             archiver: IArchiver;
             authenticationStrategies: IAuthenticationStrategy[];
+            externalCacheServices: IExternalCacheService[];
             config: IUsecaseConfig;
             requestContext: IRequestContext;
             storages: IStorages;
@@ -62,6 +67,7 @@ export default abstract class Usecase {
         return new UsecaseClass({
             archiver: this.archiver,
             authenticationStrategies: this.authenticationStrategies,
+            externalCacheServices: this.externalCacheServices,
             config: this.config,
             requestContext: this.requestContext,
             storages: this.storages

--- a/core/src/common/errors.ts
+++ b/core/src/common/errors.ts
@@ -143,6 +143,28 @@ export class NoBundleOrRedirectToError extends Error {
     }
 }
 
+// External cache errors
+export class ExternalCacheDomainNotValidError extends Error {
+    constructor(domain: string) {
+        super(`${domain} is not a valid domain name`);
+    }
+}
+export class ExternalCacheConfigurationNotValidError extends Error {
+    constructor() {
+        super("Invalid external cache configuration object");
+    }
+}
+export class ConflictingExternalCacheError extends Error {
+    constructor(domain: string) {
+        super(`An external cache with domain = ${domain} already exists`);
+    }
+}
+export class ExternalCacheNotFoundError extends Error {
+    constructor(id: string) {
+        super(`No external cache found with id = ${id}`);
+    }
+}
+
 // Group and role errors
 export class GroupNotFoundError extends Error {
     constructor(id: string) {

--- a/core/src/dependencies/IExternalCacheService.ts
+++ b/core/src/dependencies/IExternalCacheService.ts
@@ -1,0 +1,6 @@
+import { IExternalCache } from "../entities/ExternalCache";
+
+export default interface IExternalCacheService {
+    type: string;
+    purge(configuration: IExternalCache["configuration"]): Promise<void>;
+}

--- a/core/src/dependencies/IExternalCachesStorage.ts
+++ b/core/src/dependencies/IExternalCachesStorage.ts
@@ -1,0 +1,26 @@
+import { IExternalCache } from "../entities/ExternalCache";
+
+export default interface IExternalCachesStorage {
+    findOne(id: string): Promise<IExternalCache | null>;
+    findOneByDomain(domain: string): Promise<IExternalCache | null>;
+    findMany(): Promise<IExternalCache[]>;
+    oneExistsWithDomain(domain: string): Promise<boolean>;
+    createOne(externalCache: {
+        id: string;
+        type: string;
+        domain: string;
+        configuration: IExternalCache["configuration"];
+        createdAt: Date;
+        updatedAt: Date;
+    }): Promise<IExternalCache>;
+    updateOne(
+        id: string,
+        patch: {
+            type?: string;
+            domain?: string;
+            configuration?: IExternalCache["configuration"];
+            updatedAt: Date;
+        }
+    ): Promise<IExternalCache>;
+    deleteOne(id: string): Promise<void>;
+}

--- a/core/src/dependencies/IStorages.ts
+++ b/core/src/dependencies/IStorages.ts
@@ -2,6 +2,7 @@ import { IHealthCheckResult } from "../entities/HealthCheckResult";
 import IAppsStorage from "./IAppsStorage";
 import IBundlesStorage from "./IBundlesStorage";
 import IEntrypointsStorage from "./IEntrypointsStorage";
+import IExternalCachesStorage from "./IExternalCachesStorage";
 import IGroupsStorage from "./IGroupsStorage";
 import IOperationLogsStorage from "./IOperationLogsStorage";
 import IUsersStorage from "./IUsersStorage";
@@ -10,6 +11,7 @@ export default interface IStorages {
     apps: IAppsStorage;
     bundles: IBundlesStorage;
     entrypoints: IEntrypointsStorage;
+    externalCaches: IExternalCachesStorage;
     groups: IGroupsStorage;
     operationLogs: IOperationLogsStorage;
     users: IUsersStorage;

--- a/core/src/entities/ExternalCache.ts
+++ b/core/src/entities/ExternalCache.ts
@@ -1,0 +1,39 @@
+import { every, isPlainObject, isString } from "lodash";
+
+import {
+    ExternalCacheConfigurationNotValidError,
+    ExternalCacheDomainNotValidError
+} from "../common/errors";
+import isFQDN from "validator/lib/isFQDN";
+
+export interface IExternalCache {
+    id: string;
+    domain: string;
+    type: string;
+    configuration: {
+        [key: string]: string;
+    };
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+export function isExternalCacheDomainValid(domain: string): boolean {
+    return isFQDN(domain);
+}
+export function validateExternalCacheDomain(domain: string): void {
+    if (!isExternalCacheDomainValid(domain)) {
+        throw new ExternalCacheDomainNotValidError(domain);
+    }
+}
+
+/*
+ *  A valid external cache configuration object is a (string, string) dictionary
+ */
+export function isExternalCacheConfigurationValid(configuration: any): boolean {
+    return isPlainObject(configuration) && every(configuration, isString);
+}
+export function validateExternalCacheConfiguration(configuration: any): void {
+    if (!isExternalCacheConfigurationValid(configuration)) {
+        throw new ExternalCacheConfigurationNotValidError();
+    }
+}

--- a/core/src/entities/OperationLog.ts
+++ b/core/src/entities/OperationLog.ts
@@ -13,6 +13,11 @@ export enum Operation {
     UpdateEntrypoint = "entrypoints:update",
     DeleteEntrypoint = "entrypoints:delete",
 
+    // External Caches
+    CreateExternalCache = "externalCaches:create",
+    UpdateExternalCache = "externalCaches:update",
+    DeleteExternalCache = "externalCaches:delete",
+
     // Groups
     CreateGroup = "groups:create",
     UpdateGroup = "groups:update",

--- a/core/src/services/Authorizer.ts
+++ b/core/src/services/Authorizer.ts
@@ -111,6 +111,20 @@ export default class Authorizer {
         return this.ensureAuthenticated();
     }
 
+    // External caches
+    ensureCanCreateExternalCache(): Promise<void> {
+        return this.ensureAuthorized(() => this.matchesRole([RoleName.Root]));
+    }
+    ensureCanUpdateExternalCache(): Promise<void> {
+        return this.ensureAuthorized(() => this.matchesRole([RoleName.Root]));
+    }
+    ensureCanDeleteExternalCache(): Promise<void> {
+        return this.ensureAuthorized(() => this.matchesRole([RoleName.Root]));
+    }
+    ensureCanGetExternalCaches(): Promise<void> {
+        return this.ensureAuthenticated();
+    }
+
     // Groups
     ensureCanCreateGroup(): Promise<void> {
         return this.ensureAuthorized(() => this.matchesRole([RoleName.Root]));

--- a/core/src/usecases/CreateExternalCache.ts
+++ b/core/src/usecases/CreateExternalCache.ts
@@ -1,0 +1,52 @@
+import { ConflictingExternalCacheError } from "../common/errors";
+import generateId from "../common/generateId";
+import Usecase from "../common/Usecase";
+import {
+    IExternalCache,
+    validateExternalCacheConfiguration,
+    validateExternalCacheDomain
+} from "../entities/ExternalCache";
+import { Operation } from "../entities/OperationLog";
+
+export default class CreateExternalCache extends Usecase {
+    async exec(partial: {
+        domain: string;
+        type: string;
+        configuration: IExternalCache["configuration"];
+    }): Promise<IExternalCache> {
+        // Auth check
+        await this.authorizer.ensureCanCreateExternalCache();
+
+        // Validate domain and configuration
+        validateExternalCacheDomain(partial.domain);
+        validateExternalCacheConfiguration(partial.configuration);
+
+        // Ensure no externalCache with the same domain exists
+        const conflictingExternalCacheExists = await this.storages.externalCaches.oneExistsWithDomain(
+            partial.domain
+        );
+        if (conflictingExternalCacheExists) {
+            throw new ConflictingExternalCacheError(partial.domain);
+        }
+
+        // Create the externalCache
+        const now = new Date();
+        const createdExternalCache = await this.storages.externalCaches.createOne(
+            {
+                id: generateId(),
+                domain: partial.domain,
+                type: partial.type,
+                configuration: partial.configuration,
+                createdAt: now,
+                updatedAt: now
+            }
+        );
+
+        // Log the operation
+        await this.operationLogger.logOperation(Operation.CreateExternalCache, {
+            createdExternalCache
+        });
+
+        return createdExternalCache;
+    }
+}

--- a/core/src/usecases/DeleteExternalCache.ts
+++ b/core/src/usecases/DeleteExternalCache.ts
@@ -1,0 +1,27 @@
+import { ExternalCacheNotFoundError } from "../common/errors";
+import Usecase from "../common/Usecase";
+import { Operation } from "../entities/OperationLog";
+
+export default class DeleteExternalCache extends Usecase {
+    async exec(id: string): Promise<void> {
+        const toBeDeletedExternalCache = await this.storages.externalCaches.findOne(
+            id
+        );
+
+        // Ensure the externalCache exists
+        if (!toBeDeletedExternalCache) {
+            throw new ExternalCacheNotFoundError(id);
+        }
+
+        // Auth check
+        await this.authorizer.ensureCanDeleteExternalCache();
+
+        // Delete the externalCache
+        await this.storages.externalCaches.deleteOne(id);
+
+        // Log the operation
+        await this.operationLogger.logOperation(Operation.DeleteExternalCache, {
+            deletedExternalCache: toBeDeletedExternalCache
+        });
+    }
+}

--- a/core/src/usecases/GetExternalCache.ts
+++ b/core/src/usecases/GetExternalCache.ts
@@ -1,0 +1,19 @@
+import { ExternalCacheNotFoundError } from "../common/errors";
+import Usecase from "../common/Usecase";
+import { IExternalCache } from "../entities/ExternalCache";
+
+export default class GetExternalCache extends Usecase {
+    async exec(id: string): Promise<IExternalCache> {
+        // Auth check
+        await this.authorizer.ensureCanGetExternalCaches();
+
+        const externalCache = await this.storages.externalCaches.findOne(id);
+
+        // Ensure the externalCache exists
+        if (!externalCache) {
+            throw new ExternalCacheNotFoundError(id);
+        }
+
+        return externalCache;
+    }
+}

--- a/core/src/usecases/GetExternalCaches.ts
+++ b/core/src/usecases/GetExternalCaches.ts
@@ -1,0 +1,11 @@
+import Usecase from "../common/Usecase";
+import { IExternalCache } from "../entities/ExternalCache";
+
+export default class GetExternalCaches extends Usecase {
+    async exec(): Promise<IExternalCache[]> {
+        // Auth check
+        await this.authorizer.ensureCanGetExternalCaches();
+
+        return this.storages.externalCaches.findMany();
+    }
+}

--- a/core/src/usecases/UpdateExternalCache.ts
+++ b/core/src/usecases/UpdateExternalCache.ts
@@ -1,0 +1,58 @@
+import { ExternalCacheNotFoundError } from "../common/errors";
+import Usecase from "../common/Usecase";
+import {
+    IExternalCache,
+    validateExternalCacheDomain,
+    validateExternalCacheConfiguration
+} from "../entities/ExternalCache";
+import { Operation } from "../entities/OperationLog";
+
+export default class UpdateExternalCache extends Usecase {
+    async exec(
+        id: string,
+        patch: {
+            domain?: string;
+            type?: string;
+            configuration?: IExternalCache["configuration"];
+        }
+    ): Promise<IExternalCache> {
+        const existingExternalCache = await this.storages.externalCaches.findOne(
+            id
+        );
+
+        // Ensure the externalCache exists
+        if (!existingExternalCache) {
+            throw new ExternalCacheNotFoundError(id);
+        }
+
+        // Auth check
+        await this.authorizer.ensureCanUpdateExternalCache();
+
+        // Validate domain and configuration
+        if (patch.domain) {
+            validateExternalCacheDomain(patch.domain);
+        }
+        if (patch.configuration) {
+            validateExternalCacheConfiguration(patch.configuration);
+        }
+
+        // Update the externalCache
+        const updatedExternalCache = await this.storages.externalCaches.updateOne(
+            id,
+            {
+                domain: patch.domain,
+                type: patch.type,
+                configuration: patch.configuration,
+                updatedAt: new Date()
+            }
+        );
+
+        // Log the operation
+        await this.operationLogger.logOperation(Operation.UpdateExternalCache, {
+            oldExternalCache: existingExternalCache,
+            newExternalCache: updatedExternalCache
+        });
+
+        return updatedExternalCache;
+    }
+}

--- a/core/test/entities/ExternalCache.ts
+++ b/core/test/entities/ExternalCache.ts
@@ -1,0 +1,62 @@
+import { expect } from "chai";
+
+import {
+    isExternalCacheConfigurationValid,
+    isExternalCacheDomainValid
+} from "../../src/entities/ExternalCache";
+
+describe("ExternalCache entity validator isExternalCacheDomainValid", () => {
+    describe("returns true when the passed-in domain is a valid FQDN", () => {
+        ["domain.com", "sub.domain.com"].forEach(domain => {
+            it(`case: ${domain}`, () => {
+                expect(isExternalCacheDomainValid(domain)).to.equal(true);
+            });
+        });
+    });
+
+    describe("returns false when the passed-in domain is not a valid FQDN", () => {
+        ["", "https://domain.com", "domain.com/"].forEach(domain => {
+            it(`case: ${domain}`, () => {
+                expect(isExternalCacheDomainValid(domain)).to.equal(false);
+            });
+        });
+    });
+});
+
+describe("ExternalCache entity validator isExternalCacheConfigurationValid", () => {
+    describe("returns true when the passed-in configuration is a (string, string) dictionary", () => {
+        [
+            {},
+            { key: "value" },
+            { key: "value", otherKey: "otherValue" },
+            { "key-with-special-chars": "value" }
+        ].forEach(configuration => {
+            it(`case: ${JSON.stringify(configuration)}`, () => {
+                expect(
+                    isExternalCacheConfigurationValid(configuration)
+                ).to.equal(true);
+            });
+        });
+    });
+
+    describe("returns false when the passed-in configuration is not a (string, string) dictionary", () => {
+        [
+            "not-an-object",
+            0,
+            true,
+            null,
+            [],
+            { key: 0 },
+            { key: {} },
+            { key: [] },
+            { key: true },
+            { key: null }
+        ].forEach(configuration => {
+            it(`case: ${JSON.stringify(configuration)}`, () => {
+                expect(
+                    isExternalCacheConfigurationValid(configuration)
+                ).to.equal(false);
+            });
+        });
+    });
+});

--- a/core/test/services/Authorizer.ts
+++ b/core/test/services/Authorizer.ts
@@ -309,6 +309,65 @@ describe("service Authorizer", () => {
         });
     });
 
+    // External caches
+    describe("ensureCanCreateExternalCache", () => {
+        it("throws MissingRoleError if the user is not allowed to create the external cache", async () => {
+            const authorizer = getAuthorizerForUser({ id: "id", roles: [] });
+            const ensurePromise = authorizer.ensureCanCreateExternalCache();
+            await expect(ensurePromise).to.be.rejectedWith(MissingRoleError);
+        });
+        it("doesn't throw if the user is allowed to create the external cache", async () => {
+            const authorizer = getAuthorizerForUser({
+                id: "id",
+                roles: ["root"]
+            });
+            await authorizer.ensureCanCreateExternalCache();
+        });
+    });
+    describe("ensureCanUpdateExternalCache", () => {
+        it("throws MissingRoleError if the user is not allowed to update the external cache", async () => {
+            const authorizer = getAuthorizerForUser({
+                id: "id",
+                roles: []
+            });
+            const ensurePromise = authorizer.ensureCanUpdateExternalCache();
+            await expect(ensurePromise).to.be.rejectedWith(MissingRoleError);
+        });
+        it("doesn't throw if the user is allowed to update the external cache", async () => {
+            const authorizer = getAuthorizerForUser({
+                id: "id",
+                roles: ["root"]
+            });
+            await authorizer.ensureCanUpdateExternalCache();
+        });
+    });
+    describe("ensureCanDeleteExternalCache", () => {
+        it("throws MissingRoleError if the user is not allowed to delete the external cache", async () => {
+            const authorizer = getAuthorizerForUser({
+                id: "id",
+                roles: []
+            });
+            const ensurePromise = authorizer.ensureCanDeleteExternalCache();
+            await expect(ensurePromise).to.be.rejectedWith(MissingRoleError);
+        });
+        it("doesn't throw if the user is allowed to delete the external cache", async () => {
+            const authorizer = getAuthorizerForUser({
+                id: "id",
+                roles: ["root"]
+            });
+            await authorizer.ensureCanDeleteExternalCache();
+        });
+    });
+    describe("ensureCanGetExternalCaches", () => {
+        it("doesn't throw if the user is allowed to get external caches", async () => {
+            const authorizer = getAuthorizerForUser({
+                id: "id",
+                roles: []
+            });
+            await authorizer.ensureCanGetExternalCaches();
+        });
+    });
+
     // Groups
     describe("ensureCanCreateGroup", () => {
         it("throws MissingRoleError if the user is not allowed to create the group", async () => {

--- a/core/test/testUtils.ts
+++ b/core/test/testUtils.ts
@@ -5,6 +5,8 @@ import IArchiver from "../src/dependencies/IArchiver";
 import IAuthenticationStrategy from "../src/dependencies/IAuthenticationStrategy";
 import IBundlesStorage from "../src/dependencies/IBundlesStorage";
 import IEntrypointsStorage from "../src/dependencies/IEntrypointsStorage";
+import IExternalCachesStorage from "../src/dependencies/IExternalCachesStorage";
+import IExternalCacheService from "../src/dependencies/IExternalCacheService";
 import IGroupsStorage from "../src/dependencies/IGroupsStorage";
 import IOperationLogsStorage from "../src/dependencies/IOperationLogsStorage";
 import IRequestContext from "../src/dependencies/IRequestContext";
@@ -26,6 +28,13 @@ interface IMockDependencies {
             ReturnType<IAuthenticationStrategy[method]>
         >;
     }[];
+    externalCacheServices: {
+        type: string;
+        purge: SinonStub<
+            Parameters<IExternalCacheService["purge"]>,
+            ReturnType<IExternalCacheService["purge"]>
+        >;
+    }[];
     config: IUsecaseConfig;
     requestContext: IRequestContext;
     storages: {
@@ -45,6 +54,12 @@ interface IMockDependencies {
             [method in keyof IEntrypointsStorage]: SinonStub<
                 Parameters<IEntrypointsStorage[method]>,
                 ReturnType<IEntrypointsStorage[method]>
+            >;
+        };
+        externalCaches: {
+            [method in keyof IExternalCachesStorage]: SinonStub<
+                Parameters<IExternalCachesStorage[method]>,
+                ReturnType<IExternalCachesStorage[method]>
             >;
         };
         groups: {
@@ -78,6 +93,7 @@ export function getMockDependencies(): IMockDependencies {
             makeArchive: sinon.stub()
         },
         authenticationStrategies: [],
+        externalCacheServices: [],
         config: {
             enforceAuth: false
         },
@@ -115,6 +131,15 @@ export function getMockDependencies(): IMockDependencies {
                 oneExistsWithUrlMatcher: sinon.stub(),
                 anyExistsWithAppId: sinon.stub(),
                 anyExistsWithBundleIdIn: sinon.stub(),
+                createOne: sinon.stub(),
+                updateOne: sinon.stub(),
+                deleteOne: sinon.stub()
+            },
+            externalCaches: {
+                findOne: sinon.stub(),
+                findOneByDomain: sinon.stub(),
+                findMany: sinon.stub(),
+                oneExistsWithDomain: sinon.stub(),
                 createOne: sinon.stub(),
                 updateOne: sinon.stub(),
                 deleteOne: sinon.stub()

--- a/core/test/usecases/CreateExternalCache.ts
+++ b/core/test/usecases/CreateExternalCache.ts
@@ -1,0 +1,114 @@
+import { expect } from "chai";
+import sinon from "sinon";
+
+import {
+    ExternalCacheConfigurationNotValidError,
+    ExternalCacheDomainNotValidError,
+    ConflictingExternalCacheError
+} from "../../src/common/errors";
+import { Operation } from "../../src/entities/OperationLog";
+import CreateExternalCache from "../../src/usecases/CreateExternalCache";
+import { getMockDependencies } from "../testUtils";
+
+describe("usecase CreateExternalCache", () => {
+    it("throws ExternalCacheConfigurationNotValidError if the configuration is not valid", async () => {
+        const createExternalCache = new CreateExternalCache(
+            getMockDependencies()
+        );
+        const createExternalCachePromise = createExternalCache.exec({
+            domain: "domain.com",
+            type: "type",
+            configuration: "not-valid-configuration" as any
+        });
+        await expect(createExternalCachePromise).to.be.rejectedWith(
+            ExternalCacheConfigurationNotValidError
+        );
+        await expect(createExternalCachePromise).to.be.rejectedWith(
+            "Invalid external cache configuration object"
+        );
+    });
+
+    it("throws ExternalCacheDomainNotValidError if the name is not valid", async () => {
+        const createExternalCache = new CreateExternalCache(
+            getMockDependencies()
+        );
+        const createExternalCachePromise = createExternalCache.exec({
+            domain: "https://domain.com",
+            type: "type",
+            configuration: {}
+        });
+        await expect(createExternalCachePromise).to.be.rejectedWith(
+            ExternalCacheDomainNotValidError
+        );
+        await expect(createExternalCachePromise).to.be.rejectedWith(
+            "https://domain.com is not a valid domain name"
+        );
+    });
+
+    it("throws ConflictingExternalCacheError if an externalCache with the same domain exists", async () => {
+        const deps = getMockDependencies();
+        deps.storages.externalCaches.oneExistsWithDomain.resolves(true);
+        const createExternalCache = new CreateExternalCache(deps);
+        const createExternalCachePromise = createExternalCache.exec({
+            domain: "domain.com",
+            type: "type",
+            configuration: {}
+        });
+        await expect(createExternalCachePromise).to.be.rejectedWith(
+            ConflictingExternalCacheError
+        );
+        await expect(createExternalCachePromise).to.be.rejectedWith(
+            "An external cache with domain = domain.com already exists"
+        );
+    });
+
+    it("creates an externalCache", async () => {
+        const deps = getMockDependencies();
+        const createExternalCache = new CreateExternalCache(deps);
+        await createExternalCache.exec({
+            domain: "domain.com",
+            type: "type",
+            configuration: {}
+        });
+        expect(
+            deps.storages.externalCaches.createOne
+        ).to.have.been.calledOnceWith({
+            id: sinon.match.string,
+            domain: "domain.com",
+            type: "type",
+            configuration: {},
+            createdAt: sinon.match.date,
+            updatedAt: sinon.match.date
+        });
+    });
+
+    it("logs the create externalCache operation", async () => {
+        const deps = getMockDependencies();
+        const createExternalCache = new CreateExternalCache(deps);
+        await createExternalCache.exec({
+            domain: "domain.com",
+            type: "type",
+            configuration: {}
+        });
+        expect(
+            deps.storages.operationLogs.createOne
+        ).to.have.been.calledOnceWith(
+            sinon.match.has("operation", Operation.CreateExternalCache)
+        );
+    });
+
+    it("returns the created externalCache", async () => {
+        const deps = getMockDependencies();
+        const mockCreatedExternalCache = {} as any;
+        deps.storages.externalCaches.createOne.resolves(
+            mockCreatedExternalCache
+        );
+        const createExternalCache = new CreateExternalCache(deps);
+        const createdExternalCache = await createExternalCache.exec({
+            domain: "domain.com",
+            type: "type",
+            configuration: {}
+        });
+        expect(createdExternalCache).to.equal(mockCreatedExternalCache);
+    });
+});

--- a/core/test/usecases/DeleteApp.ts
+++ b/core/test/usecases/DeleteApp.ts
@@ -21,7 +21,7 @@ describe("usecase DeleteApp", () => {
 
     it("throws AppHasEntrypointsError if the app has linked entrypoints", async () => {
         const deps = getMockDependencies();
-        deps.storages.apps.findOne.resolves({ appId: "appId" } as any);
+        deps.storages.apps.findOne.resolves({} as any);
         deps.storages.entrypoints.anyExistsWithAppId.resolves(true);
         const deleteApp = new DeleteApp(deps);
         const deleteAppPromise = deleteApp.exec("appId");
@@ -35,7 +35,7 @@ describe("usecase DeleteApp", () => {
 
     it("deletes the app", async () => {
         const deps = getMockDependencies();
-        deps.storages.apps.findOne.resolves({ appId: "appId" } as any);
+        deps.storages.apps.findOne.resolves({} as any);
         const deleteApp = new DeleteApp(deps);
         await deleteApp.exec("appId");
         expect(deps.storages.apps.deleteOne).to.have.been.calledOnceWith(
@@ -45,7 +45,7 @@ describe("usecase DeleteApp", () => {
 
     it("logs the delete app operation", async () => {
         const deps = getMockDependencies();
-        deps.storages.apps.findOne.resolves({ appId: "appId" } as any);
+        deps.storages.apps.findOne.resolves({} as any);
         const deleteApp = new DeleteApp(deps);
         await deleteApp.exec("appId");
         expect(

--- a/core/test/usecases/DeleteExternalCache.ts
+++ b/core/test/usecases/DeleteExternalCache.ts
@@ -1,0 +1,46 @@
+import { expect } from "chai";
+import sinon from "sinon";
+
+import { ExternalCacheNotFoundError } from "../../src/common/errors";
+import { Operation } from "../../src/entities/OperationLog";
+import DeleteExternalCache from "../../src/usecases/DeleteExternalCache";
+import { getMockDependencies } from "../testUtils";
+
+describe("usecase DeleteExternalCache", () => {
+    it("throws ExternalCacheNotFoundError if no externalCache with the specified id exists", async () => {
+        const deleteExternalCache = new DeleteExternalCache(
+            getMockDependencies()
+        );
+        const deleteExternalCachePromise = deleteExternalCache.exec(
+            "externalCacheId"
+        );
+        await expect(deleteExternalCachePromise).to.be.rejectedWith(
+            ExternalCacheNotFoundError
+        );
+        await expect(deleteExternalCachePromise).to.be.rejectedWith(
+            "No external cache found with id = externalCacheId"
+        );
+    });
+
+    it("deletes the externalCache", async () => {
+        const deps = getMockDependencies();
+        deps.storages.externalCaches.findOne.resolves({} as any);
+        const deleteExternalCache = new DeleteExternalCache(deps);
+        await deleteExternalCache.exec("externalCacheId");
+        expect(
+            deps.storages.externalCaches.deleteOne
+        ).to.have.been.calledOnceWith("externalCacheId");
+    });
+
+    it("logs the delete externalCache operation", async () => {
+        const deps = getMockDependencies();
+        deps.storages.externalCaches.findOne.resolves({} as any);
+        const deleteExternalCache = new DeleteExternalCache(deps);
+        await deleteExternalCache.exec("externalCacheId");
+        expect(
+            deps.storages.operationLogs.createOne
+        ).to.have.been.calledOnceWith(
+            sinon.match.has("operation", Operation.DeleteExternalCache)
+        );
+    });
+});

--- a/core/test/usecases/GetExternalCache.ts
+++ b/core/test/usecases/GetExternalCache.ts
@@ -1,0 +1,29 @@
+import { expect } from "chai";
+
+import { ExternalCacheNotFoundError } from "../../src/common/errors";
+import GetExternalCache from "../../src/usecases/GetExternalCache";
+import { getMockDependencies } from "../testUtils";
+
+describe("usecase GetExternalCache", () => {
+    it("throws ExternalCacheNotFoundError if an externalCache with the specified id doesn't exist", async () => {
+        const getExternalCache = new GetExternalCache(getMockDependencies());
+        const getExternalCachePromise = getExternalCache.exec(
+            "externalCacheId"
+        );
+        await expect(getExternalCachePromise).to.be.rejectedWith(
+            ExternalCacheNotFoundError
+        );
+        await expect(getExternalCachePromise).to.be.rejectedWith(
+            "No external cache found with id = externalCacheId"
+        );
+    });
+
+    it("returns the externalCache with the specified id", async () => {
+        const deps = getMockDependencies();
+        const mockExternalCache = {} as any;
+        deps.storages.externalCaches.findOne.resolves(mockExternalCache);
+        const getExternalCache = new GetExternalCache(deps);
+        const externalCache = await getExternalCache.exec("externalCacheId");
+        expect(externalCache).to.equal(mockExternalCache);
+    });
+});

--- a/core/test/usecases/GetExternalCaches.ts
+++ b/core/test/usecases/GetExternalCaches.ts
@@ -1,0 +1,15 @@
+import { expect } from "chai";
+
+import GetExternalCaches from "../../src/usecases/GetExternalCaches";
+import { getMockDependencies } from "../testUtils";
+
+describe("usecase GetExternalCaches", () => {
+    it("returns the externalCaches found with the specified search filters (none for now)", async () => {
+        const deps = getMockDependencies();
+        const mockExternalCaches = [] as any;
+        deps.storages.externalCaches.findMany.resolves(mockExternalCaches);
+        const getExternalCaches = new GetExternalCaches(deps);
+        const externalCaches = await getExternalCaches.exec();
+        expect(externalCaches).to.equal(mockExternalCaches);
+    });
+});

--- a/core/test/usecases/UpdateApp.ts
+++ b/core/test/usecases/UpdateApp.ts
@@ -21,7 +21,7 @@ describe("usecase UpdateApp", () => {
 
     it("throws ConfigurationNotValidError if the defaultConfiguration is not valid", async () => {
         const deps = getMockDependencies();
-        deps.storages.apps.findOne.resolves({ appId: "appId" } as any);
+        deps.storages.apps.findOne.resolves({} as any);
         const updateApp = new UpdateApp(deps);
         const updateAppPromise = updateApp.exec("appId", {
             defaultConfiguration: "not-valid-configuration" as any
@@ -36,7 +36,7 @@ describe("usecase UpdateApp", () => {
 
     it("updates the app", async () => {
         const deps = getMockDependencies();
-        deps.storages.apps.findOne.resolves({ appId: "appId" } as any);
+        deps.storages.apps.findOne.resolves({} as any);
         const updateApp = new UpdateApp(deps);
         await updateApp.exec("appId", { defaultConfiguration: {} });
         expect(deps.storages.apps.updateOne).to.have.been.calledOnceWith(
@@ -50,7 +50,7 @@ describe("usecase UpdateApp", () => {
 
     it("logs the update app operation", async () => {
         const deps = getMockDependencies();
-        deps.storages.apps.findOne.resolves({ appId: "appId" } as any);
+        deps.storages.apps.findOne.resolves({} as any);
         const updateApp = new UpdateApp(deps);
         await updateApp.exec("appId", {});
         expect(
@@ -63,7 +63,7 @@ describe("usecase UpdateApp", () => {
     it("returns the updated app", async () => {
         const deps = getMockDependencies();
         const mockUpdatedApp = {} as any;
-        deps.storages.apps.findOne.resolves({ appId: "appId" } as any);
+        deps.storages.apps.findOne.resolves({} as any);
         deps.storages.apps.updateOne.resolves(mockUpdatedApp);
         const updateApp = new UpdateApp(deps);
         const updatedApp = await updateApp.exec("appId", {});

--- a/core/test/usecases/UpdateExternalCache.ts
+++ b/core/test/usecases/UpdateExternalCache.ts
@@ -1,0 +1,105 @@
+import { expect } from "chai";
+import sinon from "sinon";
+
+import {
+    ExternalCacheConfigurationNotValidError,
+    ExternalCacheDomainNotValidError,
+    ExternalCacheNotFoundError
+} from "../../src/common/errors";
+import { Operation } from "../../src/entities/OperationLog";
+import UpdateExternalCache from "../../src/usecases/UpdateExternalCache";
+import { getMockDependencies } from "../testUtils";
+
+describe("usecase UpdateExternalCache", () => {
+    it("throws ExternalCacheNotFoundError if no externalCache with the specified id exists", async () => {
+        const updateExternalCache = new UpdateExternalCache(
+            getMockDependencies()
+        );
+        const updateExternalCachePromise = updateExternalCache.exec(
+            "externalCacheId",
+            {}
+        );
+        await expect(updateExternalCachePromise).to.be.rejectedWith(
+            ExternalCacheNotFoundError
+        );
+        await expect(updateExternalCachePromise).to.be.rejectedWith(
+            "No external cache found with id = externalCacheId"
+        );
+    });
+
+    it("throws ExternalCacheConfigurationNotValidError if the configuration is not valid", async () => {
+        const deps = getMockDependencies();
+        deps.storages.externalCaches.findOne.resolves({} as any);
+        const updateExternalCache = new UpdateExternalCache(deps);
+        const updateExternalCachePromise = updateExternalCache.exec(
+            "externalCacheId",
+            { configuration: "not-valid-configuration" as any }
+        );
+        await expect(updateExternalCachePromise).to.be.rejectedWith(
+            ExternalCacheConfigurationNotValidError
+        );
+        await expect(updateExternalCachePromise).to.be.rejectedWith(
+            "Invalid external cache configuration object"
+        );
+    });
+
+    it("throws ExternalCacheDomainNotValidError if the domain is not valid", async () => {
+        const deps = getMockDependencies();
+        deps.storages.externalCaches.findOne.resolves({} as any);
+        const updateExternalCache = new UpdateExternalCache(deps);
+        const updateExternalCachePromise = updateExternalCache.exec(
+            "externalCacheId",
+            { domain: "https://domain.com" }
+        );
+        await expect(updateExternalCachePromise).to.be.rejectedWith(
+            ExternalCacheDomainNotValidError
+        );
+        await expect(updateExternalCachePromise).to.be.rejectedWith(
+            "https://domain.com is not a valid domain name"
+        );
+    });
+
+    it("updates the externalCache", async () => {
+        const deps = getMockDependencies();
+        deps.storages.externalCaches.findOne.resolves({} as any);
+        const updateExternalCache = new UpdateExternalCache(deps);
+        await updateExternalCache.exec("externalCacheId", {
+            configuration: {}
+        });
+        expect(
+            deps.storages.externalCaches.updateOne
+        ).to.have.been.calledOnceWith("externalCacheId", {
+            domain: undefined,
+            type: undefined,
+            configuration: {},
+            updatedAt: sinon.match.date
+        });
+    });
+
+    it("logs the update externalCache operation", async () => {
+        const deps = getMockDependencies();
+        deps.storages.externalCaches.findOne.resolves({} as any);
+        const updateExternalCache = new UpdateExternalCache(deps);
+        await updateExternalCache.exec("externalCacheId", {});
+        expect(
+            deps.storages.operationLogs.createOne
+        ).to.have.been.calledOnceWith(
+            sinon.match.has("operation", Operation.UpdateExternalCache)
+        );
+    });
+
+    it("returns the updated externalCache", async () => {
+        const deps = getMockDependencies();
+        const mockUpdatedExternalCache = {} as any;
+        deps.storages.externalCaches.findOne.resolves({} as any);
+        deps.storages.externalCaches.updateOne.resolves(
+            mockUpdatedExternalCache
+        );
+        const updateExternalCache = new UpdateExternalCache(deps);
+        const updatedExternalCache = await updateExternalCache.exec(
+            "externalCacheId",
+            {}
+        );
+        expect(updatedExternalCache).to.equal(mockUpdatedExternalCache);
+    });
+});


### PR DESCRIPTION
TODO:

- [ ] CRUD for external caches
  - [x] core
  - [ ] storages
  - [ ] API and sdk
  - [ ] management console
- [ ] purge external cache on entrypoint update
  - [ ] core usecase
  - [ ] AWS CloudFront service + configuration UI
  - [ ] Azure CDN service + configuration UI
- [ ] document feature